### PR TITLE
make LoginResponse['authResponse'] non-empty in onSuccess

### DIFF
--- a/src/types/params.type.ts
+++ b/src/types/params.type.ts
@@ -96,7 +96,7 @@ export type FacebookLoginProps = Pick<InitParams, 'appId'> & {
    * @default 'name,email,picture' */
   fields?: string;
 
-  onSuccess?: (res: LoginResponse['authResponse']) => void;
+  onSuccess?: (res: LoginResponse['authResponse']!) => void;
 
   onFail?: (err: { status: string }) => void;
 


### PR DESCRIPTION
It is checked in code to be non-empty, but the type allows it to be undefined