### PR TITLE
Fix some of the typings

### DIFF
--- a/src/types/params.type.ts
+++ b/src/types/params.type.ts
@@ -1,7 +1,7 @@
 import { CSSProperties, ReactElement, ReactNode, ReactNodeArray } from 'react';
 import { FB } from './fb.type';
 
-import { LoginResponse } from './response.type';
+import { AuthResponse } from './response.type';
 
 export type InitParams = {
   /** Your application ID. */
@@ -104,7 +104,7 @@ export type FacebookLoginProps = Pick<InitParams, 'appId'> & {
    * @default 'name,email,picture' */
   fields?: string;
 
-  onSuccess?: (res: LoginResponse['authResponse']) => void;
+  onSuccess?: (res: AuthResponse) => void;
 
   onFail?: (err: { status: string }) => void;
 

--- a/src/types/params.type.ts
+++ b/src/types/params.type.ts
@@ -1,7 +1,7 @@
 import { CSSProperties, ReactElement, ReactNode, ReactNodeArray } from 'react';
 import { FB } from './fb.type';
 
-import { AuthResponse, LoginResponseError } from './response.type';
+import { AuthResponse, LoginResponseError, MeResponse } from './response.type';
 
 export type InitParams = {
   /** Your application ID. */
@@ -108,7 +108,7 @@ export type FacebookLoginProps = Pick<InitParams, 'appId'> & {
 
   onFail?: (err: LoginResponseError) => void;
 
-  onProfileSuccess?: (res: unknown) => void;
+  onProfileSuccess?: (res: MeResponse) => void;
 
   className?: string;
 

--- a/src/types/params.type.ts
+++ b/src/types/params.type.ts
@@ -1,7 +1,7 @@
 import { CSSProperties, ReactElement, ReactNode, ReactNodeArray } from 'react';
 import { FB } from './fb.type';
 
-import { AuthResponse } from './response.type';
+import { AuthResponse, LoginResponseError } from './response.type';
 
 export type InitParams = {
   /** Your application ID. */
@@ -106,7 +106,7 @@ export type FacebookLoginProps = Pick<InitParams, 'appId'> & {
 
   onSuccess?: (res: AuthResponse) => void;
 
-  onFail?: (err: { status: string }) => void;
+  onFail?: (err: LoginResponseError) => void;
 
   onProfileSuccess?: (res: unknown) => void;
 

--- a/src/types/params.type.ts
+++ b/src/types/params.type.ts
@@ -1,7 +1,7 @@
 import { CSSProperties, ReactElement, ReactNode, ReactNodeArray } from 'react';
 import { FB } from './fb.type';
 
-import { AuthResponse, LoginResponseError, MeResponse } from './response.type';
+import { SuccessResponse, FailResponse, ProfileSuccessResponse } from './response.type';
 
 export type InitParams = {
   /** Your application ID. */
@@ -104,11 +104,11 @@ export type FacebookLoginProps = Pick<InitParams, 'appId'> & {
    * @default 'name,email,picture' */
   fields?: string;
 
-  onSuccess?: (res: AuthResponse) => void;
+  onSuccess?: (res: SuccessResponse) => void;
 
-  onFail?: (err: LoginResponseError) => void;
+  onFail?: (err: FailResponse) => void;
 
-  onProfileSuccess?: (res: MeResponse) => void;
+  onProfileSuccess?: (res: ProfileSuccessResponse) => void;
 
   className?: string;
 

--- a/src/types/response.type.ts
+++ b/src/types/response.type.ts
@@ -52,5 +52,8 @@ export type ProfileSuccessResponse = {
       is_silhouette: boolean,
       url: string,
     }
-  }
+  },
+  // This response will change depending on fields param
+  //eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any;
 };

--- a/src/types/response.type.ts
+++ b/src/types/response.type.ts
@@ -32,4 +32,8 @@ export type AuthResponse = {
   userID: string;
 };
 
+export type LoginResponseError = { 
+  status: 'loginCancelled' | 'facebookNotLoaded' 
+}
+
 export type MeResponse = {};

--- a/src/types/response.type.ts
+++ b/src/types/response.type.ts
@@ -6,10 +6,10 @@ export enum LoginStatus {
 
 export type LoginResponse = {
   status: LoginStatus;
-  authResponse?: AuthResponse;
+  authResponse?: SuccessResponse;
 };
 
-export type AuthResponse = {
+export type SuccessResponse = {
   /** An access token for the person using the webpage. */
   accessToken: string;
 
@@ -32,7 +32,7 @@ export type AuthResponse = {
   userID: string;
 };
 
-export type LoginResponseError = { 
+export type FailResponse = { 
   status: 'loginCancelled' | 'facebookNotLoaded' 
 }
 
@@ -41,7 +41,7 @@ export type LoginResponseError = {
  * 
  * @see https://developers.facebook.com/docs/graph-api/reference/user/
  */
-export type MeResponse = {
+export type ProfileSuccessResponse = {
   id?: string,
   email?: string,
   name?: string,

--- a/src/types/response.type.ts
+++ b/src/types/response.type.ts
@@ -36,4 +36,21 @@ export type LoginResponseError = {
   status: 'loginCancelled' | 'facebookNotLoaded' 
 }
 
-export type MeResponse = {};
+/**
+ * Response from /me endpoint. These values will vary depending on provided fields param.
+ * 
+ * @see https://developers.facebook.com/docs/graph-api/reference/user/
+ */
+export type MeResponse = {
+  id?: string,
+  email?: string,
+  name?: string,
+  picture?: {
+    data: {
+      height: number,
+      width: string,
+      is_silhouette: boolean,
+      url: string,
+    }
+  }
+};

--- a/src/types/response.type.ts
+++ b/src/types/response.type.ts
@@ -6,28 +6,30 @@ export enum LoginStatus {
 
 export type LoginResponse = {
   status: LoginStatus;
-  authResponse?: {
-    /** An access token for the person using the webpage. */
-    accessToken: string;
+  authResponse?: AuthResponse;
+};
 
-    /**
-     * A UNIX time stamp when the token expires. Once the token expires, the person will need to login again.
-     */
-    expiresIn: string;
+export type AuthResponse = {
+  /** An access token for the person using the webpage. */
+  accessToken: string;
 
-    /**
-     * The amount of time before the login expires, in seconds, and the person will need to login again.
-     */
-    reauthorize_required_in: string;
+  /**
+   * A UNIX time stamp when the token expires. Once the token expires, the person will need to login again.
+   */
+  expiresIn: string;
 
-    /**
-     * A signed parameter that contains information about the person using your webpage.
-     */
-    signedRequest: string;
+  /**
+   * The amount of time before the login expires, in seconds, and the person will need to login again.
+   */
+  reauthorize_required_in: string;
 
-    /** The ID of the person using your webpage. */
-    userID: string;
-  };
+  /**
+   * A signed parameter that contains information about the person using your webpage.
+   */
+  signedRequest: string;
+
+  /** The ID of the person using your webpage. */
+  userID: string;
 };
 
 export type MeResponse = {};


### PR DESCRIPTION
Hey! I'm currently using this library in the Typescript project and it works great! But, I've noticed there is some typing missing in component callbacks so I've added them.

These changes were made so you can now add typings to all of the callbacks

```tsx
<FacebookLogin
	appId="app id"
	onSuccess={(response: AuthResponse) => {
		console.log('Login Success!', response);
	}}
	onFail={(error: LoginResponseError) => {
		console.log('Login Failed!', error);
	}}
	onProfileSuccess={(response: MeResponse) => {
		console.log('Get Profile Success!', response);
	}}
/>
```

- `LoginResponse` was split into two classes `LoginResponse` and  `AuthResponse`. `onSuccess` now returns the new class `AuthResponse` rather than `LoginResponse['authResponse']`
- `onFail` error was moved into its own type `LoginResponseError` rather than typing it inline.
- `MeResponse` that was left unused for some reason is now used and properly typed.