### PR TITLE
fix(): resolve createScriptEle if exists

### DIFF
--- a/src/helpers/dom.helper.ts
+++ b/src/helpers/dom.helper.ts
@@ -5,6 +5,7 @@ export const createScriptEle = (id: string, src: string) => {
 
     // return if script already exists
     if (document.getElementById(id)) {
+      resolve(undefined);
       return;
     }
 


### PR DESCRIPTION
With `FacebookLoginClient.loadSdk`, it resolves the promise only the first time it's called. Next time, when the script element already exists in the document, it hangs without resolving or rejection. This fix resolves successfully if the script has already been added to the document.